### PR TITLE
Refactoring util functions

### DIFF
--- a/cmip6_downscaling/data/cmip.py
+++ b/cmip6_downscaling/data/cmip.py
@@ -213,7 +213,6 @@ def load_cmip(
         .df['zstore']
         .to_list()
     )
-    print(stores)
     if len(stores) > 1:
         raise ValueError('can only get 1 store at a time')
     if return_type == 'zarr':

--- a/cmip6_downscaling/data/cmip.py
+++ b/cmip6_downscaling/data/cmip.py
@@ -213,6 +213,7 @@ def load_cmip(
         .df['zstore']
         .to_list()
     )
+    print(stores)
     if len(stores) > 1:
         raise ValueError('can only get 1 store at a time')
     if return_type == 'zarr':
@@ -269,3 +270,19 @@ def gcm_munge(ds: xr.Dataset) -> xr.Dataset:
         ds = ds.drop('height')
     ds = ds.squeeze(drop=True)
     return ds
+
+
+def get_gcm_grid_spec(gcm: str) -> str:
+    gcm_grid = load_cmip(
+        source_ids=gcm,
+        return_type='xr',
+    ).sel(time=0)
+
+    nlat = len(gcm_grid.lat)
+    nlon = len(gcm_grid.lon)
+    lat_spacing = int(round(abs(gcm_grid.lat[0] - gcm_grid.lat[1]), 1) * 10)
+    lon_spacing = int(round(abs(gcm_grid.lon[0] - gcm_grid.lon[1]), 1) * 10)
+    min_lat = int(round(gcm_grid.lat.min(), 1))
+    min_lon = int(round(gcm_grid.lon.min(), 1))
+
+    return f'{nlat:d}x{nlon:d}_gridsize_{lat_spacing:d}_{lon_spacing:d}_llcorner_{min_lat:d}_{min_lon:d}'

--- a/cmip6_downscaling/data/cmip.py
+++ b/cmip6_downscaling/data/cmip.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import List, Union
 
 import intake
+import numpy as np
 import pandas as pd
 import xarray as xr
 import zarr
@@ -275,13 +276,13 @@ def get_gcm_grid_spec(gcm: str) -> str:
     gcm_grid = load_cmip(
         source_ids=gcm,
         return_type='xr',
-    ).sel(time=0)
+    ).isel(time=0)
 
     nlat = len(gcm_grid.lat)
     nlon = len(gcm_grid.lon)
-    lat_spacing = int(round(abs(gcm_grid.lat[0] - gcm_grid.lat[1]), 1) * 10)
-    lon_spacing = int(round(abs(gcm_grid.lon[0] - gcm_grid.lon[1]), 1) * 10)
-    min_lat = int(round(gcm_grid.lat.min(), 1))
-    min_lon = int(round(gcm_grid.lon.min(), 1))
+    lat_spacing = int(np.round(abs(gcm_grid.lat[0] - gcm_grid.lat[1]), 1) * 10)
+    lon_spacing = int(np.round(abs(gcm_grid.lon[0] - gcm_grid.lon[1]), 1) * 10)
+    min_lat = int(np.round(gcm_grid.lat.min(), 1))
+    min_lon = int(np.round(gcm_grid.lon.min(), 1))
 
     return f'{nlat:d}x{nlon:d}_gridsize_{lat_spacing:d}_{lon_spacing:d}_llcorner_{min_lat:d}_{min_lon:d}'

--- a/cmip6_downscaling/data/observations.py
+++ b/cmip6_downscaling/data/observations.py
@@ -28,7 +28,7 @@ def get_store(bucket, prefix, account_key=None):
 
 
 def open_era5(variables: Union[str, List[str]], start_year: str, end_year: str) -> xr.Dataset:
-    """Open ERA5 daily data for a single variable for period 1979-2021
+    """Open ERA5 daily data for one or more variables for period 1979-2021
 
     Parameters
     ----------

--- a/cmip6_downscaling/data/observations.py
+++ b/cmip6_downscaling/data/observations.py
@@ -1,6 +1,8 @@
 import os
 
 os.environ["PREFECT__FLOWS__CHECKPOINTING"] = "True"
+from typing import List, Union
+
 import xarray as xr
 import zarr
 
@@ -25,13 +27,13 @@ def get_store(bucket, prefix, account_key=None):
     return store
 
 
-def open_era5(var: str, start_year: str, end_year: str) -> xr.Dataset:
+def open_era5(variables: Union[str, List[str]], start_year: str, end_year: str) -> xr.Dataset:
     """Open ERA5 daily data for a single variable for period 1979-2021
 
     Parameters
     ----------
-    var : str
-        The variable you want to grab from the ERA5 dataset.
+    variables : str or list of string
+        The variable(s) you want to grab from the ERA5 dataset.
 
     start_year : str
         The first year of the time period you want to grab from ERA5 dataset.
@@ -44,9 +46,12 @@ def open_era5(var: str, start_year: str, end_year: str) -> xr.Dataset:
     xarray.Dataset
         A daily dataset for one variable.
     """
+    if isinstance(variables, str):
+        variables = [variables]
+
     stores = [
         f'https://cmip6downscaling.blob.core.windows.net/cmip6/ERA5_daily/{y}'
         for y in range(int(start_year), int(end_year) + 1)
     ]
     ds = xr.open_mfdataset(stores, engine='zarr', consolidated=True)
-    return ds[[var]]
+    return ds[variables]

--- a/cmip6_downscaling/workflows/paths.py
+++ b/cmip6_downscaling/workflows/paths.py
@@ -6,7 +6,7 @@ def build_obs_identifier(
     train_period_start: str,
     train_period_end: str,
     variables: Union[str, List[str]],
-    chunk_by: str,
+    chunking_approach: str,
 ) -> str:
     """
     Build the common identifier for observation related data: the same pattern is used for: 1) chunked raw obs, 2) coarsened obs, and 3) coarsened then interpolated obs
@@ -21,8 +21,8 @@ def build_obs_identifier(
         From run hyperparameters
     variables : str
         From run hyperparameters
-    chunk_by: str
-        Whether the data is chunked by time or space
+    chunking_approach: str
+        'full_space' or 'full_time'
 
     Returns
     -------
@@ -32,7 +32,7 @@ def build_obs_identifier(
     if isinstance(variables, str):
         variables = [variables]
     var_string = '_'.join(variables)
-    return f'{obs}_{train_period_start}_{train_period_end}_{var_string}_{chunk_by}_chunked'
+    return f'{obs}_{train_period_start}_{train_period_end}_{var_string}_{chunking_approach}'
 
 
 def make_rechunked_obs_path(
@@ -40,7 +40,7 @@ def make_rechunked_obs_path(
     train_period_start: str,
     train_period_end: str,
     variables: Union[str, List[str]],
-    chunk_by: str,
+    chunking_approach: str,
     workdir: str = "az://cmip6",
 ) -> str:
     """Build the path for rechunked observation
@@ -55,8 +55,8 @@ def make_rechunked_obs_path(
         From run hyperparameters
     variables : str
         From run hyperparameters
-    chunk_by: str
-        Whether the data is chunked by time or space
+    chunking_approach: str
+        'full_space' or 'full_time'
     workdir : str, optional
         Intermediate files for caching (and might be used by other gcms), by default "az://cmip6"
 
@@ -70,7 +70,7 @@ def make_rechunked_obs_path(
         train_period_start=train_period_start,
         train_period_end=train_period_end,
         variables=variables,
-        chunk_by=chunk_by,
+        chunking_approach=chunking_approach,
     )
     return f"{workdir}/intermediates/{obs_identifier}.zarr"
 
@@ -81,7 +81,7 @@ def make_coarse_obs_path(
     train_period_end: str,
     variables: Union[str, List[str]],
     gcm_grid_spec: str,
-    chunk_by: str,
+    chunking_approach: str,
     workdir: str = "az://cmip6",
 ) -> str:
     """Build the path for coarsened observation
@@ -98,8 +98,8 @@ def make_coarse_obs_path(
         From run hyperparameters
     gcm_grid_spec: str
         Output of get_gcm_grid_spec
-    chunk_by: str
-        Whether the data is chunked by time or space
+    chunking_approach: str
+        'full_space' or 'full_time'
     workdir : str, optional
         Intermediate files for caching (and might be used by other gcms), by default "az://cmip6"
 
@@ -113,7 +113,7 @@ def make_coarse_obs_path(
         train_period_start=train_period_start,
         train_period_end=train_period_end,
         variables=variables,
-        chunk_by=chunk_by,
+        chunking_approach=chunking_approach,
     )
     return f"{workdir}/intermediates/coarsened_{obs_identifier}_{gcm_grid_spec}.zarr"
 
@@ -124,7 +124,7 @@ def make_interpolated_obs_path(
     train_period_end: str,
     variables: Union[str, List[str]],
     gcm_grid_spec: str,
-    chunk_by: str,
+    chunking_approach: str,
     workdir: str = "az://cmip6",
 ) -> str:
     """Build the path for coarsened observation that has then been interpolated back to the observation grid
@@ -141,8 +141,8 @@ def make_interpolated_obs_path(
         From run hyperparameters
     gcm_grid_spec: str
         Output of get_gcm_grid_spec
-    chunk_by: str
-        Whether the data is chunked by time or space
+    chunking_approach: str
+        'full_space' or 'full_time'
     workdir : str, optional
         Intermediate files for caching (and might be used by other gcms), by default "az://cmip6"
 
@@ -156,6 +156,6 @@ def make_interpolated_obs_path(
         train_period_start=train_period_start,
         train_period_end=train_period_end,
         variables=variables,
-        chunk_by=chunk_by,
+        chunking_approach=chunking_approach,
     )
     return f"{workdir}/intermediates/interpolated_{obs_identifier}_{gcm_grid_spec}.zarr"

--- a/cmip6_downscaling/workflows/paths.py
+++ b/cmip6_downscaling/workflows/paths.py
@@ -1,0 +1,161 @@
+from typing import List, Union
+
+
+def build_obs_identifier(
+    obs: str,
+    train_period_start: str,
+    train_period_end: str,
+    variables: Union[str, List[str]],
+    chunk_by: str,
+) -> str:
+    """
+    Build the common identifier for observation related data: the same pattern is used for: 1) chunked raw obs, 2) coarsened obs, and 3) coarsened then interpolated obs
+
+    Parameters
+    ----------
+    obs : str
+        From run hyperparameters
+    train_period_start : str
+        From run hyperparameters
+    train_period_end : str
+        From run hyperparameters
+    variables : str
+        From run hyperparameters
+    chunk_by: str
+        Whether the data is chunked by time or space
+
+    Returns
+    -------
+    identifier : str
+        string to be used in obs related paths as specified by the params
+    """
+    if isinstance(variables, str):
+        variables = [variables]
+    var_string = '_'.join(variables)
+    return f'{obs}_{train_period_start}_{train_period_end}_{var_string}_{chunk_by}_chunked'
+
+
+def make_rechunked_obs_path(
+    obs: str,
+    train_period_start: str,
+    train_period_end: str,
+    variables: Union[str, List[str]],
+    chunk_by: str,
+    workdir: str = "az://cmip6",
+) -> str:
+    """Build the path for rechunked observation
+
+    Parameters
+    ----------
+    obs : str
+        From run hyperparameters
+    train_period_start : str
+        From run hyperparameters
+    train_period_end : str
+        From run hyperparameters
+    variables : str
+        From run hyperparameters
+    chunk_by: str
+        Whether the data is chunked by time or space
+    workdir : str, optional
+        Intermediate files for caching (and might be used by other gcms), by default "az://cmip6"
+
+    Returns
+    -------
+    rechunked_obs_path: str
+        Path to which rechunked observation defined by the parameters should be stored
+    """
+    obs_identifier = build_obs_identifier(
+        obs=obs,
+        train_period_start=train_period_start,
+        train_period_end=train_period_end,
+        variables=variables,
+        chunk_by=chunk_by,
+    )
+    return f"{workdir}/intermediates/{obs_identifier}.zarr"
+
+
+def make_coarse_obs_path(
+    obs: str,
+    train_period_start: str,
+    train_period_end: str,
+    variables: Union[str, List[str]],
+    gcm_grid_spec: str,
+    chunk_by: str,
+    workdir: str = "az://cmip6",
+) -> str:
+    """Build the path for coarsened observation
+
+    Parameters
+    ----------
+    obs : str
+        From run hyperparameters
+    train_period_start : str
+        From run hyperparameters
+    train_period_end : str
+        From run hyperparameters
+    variables : str
+        From run hyperparameters
+    gcm_grid_spec: str
+        Output of get_gcm_grid_spec
+    chunk_by: str
+        Whether the data is chunked by time or space
+    workdir : str, optional
+        Intermediate files for caching (and might be used by other gcms), by default "az://cmip6"
+
+    Returns
+    -------
+    coarse_obs_path: str
+        Path to which coarsened observation defined by the parameters should be stored
+    """
+    obs_identifier = build_obs_identifier(
+        obs=obs,
+        train_period_start=train_period_start,
+        train_period_end=train_period_end,
+        variables=variables,
+        chunk_by=chunk_by,
+    )
+    return f"{workdir}/intermediates/coarsened_{obs_identifier}_{gcm_grid_spec}.zarr"
+
+
+def make_interpolated_obs_path(
+    obs: str,
+    train_period_start: str,
+    train_period_end: str,
+    variables: Union[str, List[str]],
+    gcm_grid_spec: str,
+    chunk_by: str,
+    workdir: str = "az://cmip6",
+) -> str:
+    """Build the path for coarsened observation that has then been interpolated back to the observation grid
+
+    Parameters
+    ----------
+    obs : str
+        From run hyperparameters
+    train_period_start : str
+        From run hyperparameters
+    train_period_end : str
+        From run hyperparameters
+    variables : str
+        From run hyperparameters
+    gcm_grid_spec: str
+        Output of get_gcm_grid_spec
+    chunk_by: str
+        Whether the data is chunked by time or space
+    workdir : str, optional
+        Intermediate files for caching (and might be used by other gcms), by default "az://cmip6"
+
+    Returns
+    -------
+    interpolated_obs_path: str
+        Path to which interpolated observation defined by the parameters should be stored
+    """
+    obs_identifier = build_obs_identifier(
+        obs=obs,
+        train_period_start=train_period_start,
+        train_period_end=train_period_end,
+        variables=variables,
+        chunk_by=chunk_by,
+    )
+    return f"{workdir}/intermediates/interpolated_{obs_identifier}_{gcm_grid_spec}.zarr"

--- a/cmip6_downscaling/workflows/utils.py
+++ b/cmip6_downscaling/workflows/utils.py
@@ -371,7 +371,7 @@ def rechunk_zarr_array_with_caching(
         Path to where the output data is saved. If output path is not empty, the content would be loaded and the schema checked. If the schema check passed,
         the content will be returned without rechunking again (i.e. caching); else, the content can be overwritten (see overwrite option).
     chunking_approach : str
-        Has to be one of `full_space` or `full_time`. If `full_space`, the data will be rechunked such that the space dimensions are contiguous (i.e. each chunk 
+        Has to be one of `full_space` or `full_time`. If `full_space`, the data will be rechunked such that the space dimensions are contiguous (i.e. each chunk
         will contain full maps). If `full_time`, the data will be rechunked such that the time dimension is contiguous (i.e. each chunk will contain full time
         series)
     connection_string : str
@@ -389,9 +389,12 @@ def rechunk_zarr_array_with_caching(
     """
     # determine the chunking schema
     if chunking_approach == 'full_space':
-        chunk_dims = ('time', )  # if we need full maps, chunk along the time dimension 
+        chunk_dims = ('time',)  # if we need full maps, chunk along the time dimension
     elif chunking_approach == 'full_time':
-        chunk_dims = ('lat', 'lon', )  # if we need full time series, chunk along the lat/lon dimensions 
+        chunk_dims = (
+            'lat',
+            'lon',
+        )  # if we need full time series, chunk along the lat/lon dimensions
     else:
         raise NotImplementedError("chunking_approach must be in ['full_space', 'full_time']")
     chunk_def = calc_auspicious_chunks_dict(zarr_array, chunk_dims=chunk_dims)
@@ -422,7 +425,7 @@ def rechunk_zarr_array_with_caching(
         try:
             # if the content in target path is correctly chunked, return
             target_schema.validate(output)
-            return output 
+            return output
 
         except SchemaError:
             if overwrite:

--- a/cmip6_downscaling/workflows/utils.py
+++ b/cmip6_downscaling/workflows/utils.py
@@ -235,6 +235,7 @@ def regrid_dataset(
     ds: xr.Dataset,
     ds_path: Union[str, None],
     target_grid_ds: xr.Dataset,
+    variable: str,
     connection_string: str,
 ) -> Tuple[xr.Dataset, str]:
     """Regrid a dataset to a target grid. For use in both coarsening or interpolating to finer resolution.

--- a/cmip6_downscaling/workflows/utils.py
+++ b/cmip6_downscaling/workflows/utils.py
@@ -2,7 +2,7 @@ import os
 import random
 import re
 import string
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import fsspec
 import numpy as np
@@ -10,7 +10,7 @@ import xarray as xr
 import xesmf as xe
 import zarr
 from rechunker import rechunk
-from xarray_schema.core import DataArraySchema, SchemaError
+from xarray_schema.core import DataArraySchema, DatasetSchema, SchemaError
 
 schema_maps_chunks = DataArraySchema(chunks={'lat': -1, 'lon': -1})
 
@@ -51,7 +51,8 @@ def delete_chunks_encoding(ds: Union[xr.Dataset, xr.DataArray]):
 
 def make_rechunker_stores(
     connection_string: str,
-):  # -> tuple[fsspec.mapping.FSmap, fsspec.mapping.FSmap]:
+    output_path: Optional[str] = None,
+) -> Tuple[fsspec.mapping.FSmap, fsspec.mapping.FSmap, str]:
     """Initialize two stores for rechunker to use as temporary and final rechunked locations
 
     Parameters
@@ -65,10 +66,12 @@ def make_rechunker_stores(
         Stores where rechunker will write and the path to the target store
     """
     path_tmp = "az://cmip6/temp/{}.zarr".format(temp_file_name())
-    path_tgt = "az://cmip6/temp/{}.zarr".format(temp_file_name())
     temp_store = fsspec.get_mapper(path_tmp, connection_string=connection_string)
-    target_store = fsspec.get_mapper(path_tgt, connection_string=connection_string)
-    return temp_store, target_store, path_tgt
+
+    if output_path is None:
+        output_path = "az://cmip6/temp/{}.zarr".format(temp_file_name())
+    target_store = fsspec.get_mapper(output_path, connection_string=connection_string)
+    return temp_store, target_store, output_path
 
 
 def rechunk_zarr_array(
@@ -87,7 +90,7 @@ def rechunk_zarr_array(
     zarr_array : zarr or xarray dataset
         Dataset you want to rechunk.
     zarr_array_location: str
-        Path to where the data is sitting.
+        Path to where the input data is sitting. Only returned/used if zarr_array does not need to rechunked
     chunk_dims : Union[Tuple, dict]
         Information for chunking the ds. If a dict is passed, it will rechunk following sizes as specified. The dict should look like:
             {variable: {'lat': chunk_size_lat,
@@ -156,6 +159,7 @@ def rechunk_zarr_array(
             print(chunks_dict[variable])
             delete_chunks_encoding(zarr_array)
             print(zarr_array.chunk(chunks_dict[variable]))
+            # TODO: will always work but need to double check the result and if it's taking a long time
             rechunk_plan = rechunk(
                 zarr_array.chunk(chunks_dict[variable]),
                 chunks_dict,
@@ -346,3 +350,120 @@ def write_dataset(ds: xr.Dataset, path: str, chunks_dims: Tuple = ('time',)) -> 
         chunks_dict = calc_auspicious_chunks_dict(ds, chunk_dims=chunks_dims)
         delete_chunks_encoding(ds)
         ds.chunk(chunks_dict).to_zarr(store, mode='w', consolidated=True)
+
+
+def rechunk_zarr_array_with_caching(
+    zarr_array: xr.Dataset,
+    output_path: str,
+    connection_string: str,
+    variable: str,
+    chunk_dims: Union[Tuple, dict] = ('time',),
+    max_mem: str = "200MB",
+    overwrite: bool = False,
+) -> xr.Dataset:
+    """Use `rechunker` package to adjust chunks of dataset to a form
+    conducive for your processing.
+
+    Parameters
+    ----------
+    zarr_array : zarr or xarray dataset
+        Dataset you want to rechunk.
+    output_path: str
+        Path to where the output data is saved. If output path is not empty, the content would be loaded and the schema checked. If the schema check passed,
+        the content will be returned without rechunking again (i.e. caching); else, the content can be overwritten (see overwrite option).
+    chunk_dims : Union[Tuple, dict]
+        Information for chunking the ds. If a dict is passed, it will rechunk following sizes as specified. The dict should look like:
+            {variable: {'lat': chunk_size_lat,
+                        'lon': chunk_size_lon,
+                        'time': chunk_size_lon}
+            'lon': None,
+            'lat': None,
+            'time': None}.
+        If a tuple is passed, it is the dimension(s) along which you want to chunk ds, and the optimal chunk sizes will get calculated internally.
+    connection_string : str
+        Connection string to give you write access
+    max_mem : str
+        The max memory you want to allow for a chunk. Probably want it to be around 100 MB, but that
+        is also controlled by the `calc_auspicious_chunk_sizes` calls.
+    overwrite : bool
+        Whether to overwrite the content saved at output_path if the content did not pass schema check.
+
+    Returns
+    -------
+    rechunked_ds : xr.Dataset
+        Rechunked dataset
+    """
+    # determine the chunking schema
+    if type(chunk_dims) == tuple:
+        chunk_def = calc_auspicious_chunks_dict(zarr_array, chunk_dims=chunk_dims)
+        chunks_dict = {
+            'time': None,  # write None here because you don't want to rechunk this array
+            'lon': None,
+            'lat': None,
+        }
+        for var in zarr_array.data_vars:
+            chunks_dict[var] = chunk_def
+
+    elif type(chunk_dims) == dict:
+        chunks_dict = chunk_dims
+        # ensure that the chunks_dict looks the way you want it to as {variable: {'lat': chunk_size_lat, 'lon': chunk_size_lon, 'time': chunk_size_lon}
+        # 'lon': None, 'lat': None, 'time': none}
+        for var in zarr_array.data_vars:
+            assert var in chunks_dict
+            for dim in ['lat', 'lon', 'time']:
+                chunks_dict[dim] = None
+                assert dim in chunks_dict[var]
+
+    # make the schema for what you want the rechunking routine to produce
+    # so that you can check whether what you passed in (zarr_array) already looks like that
+    # if it does, you'll skip the rechunking!
+    schema_dict = {}
+    for var in zarr_array.data_vars:
+        schema_dict[var] = DataArraySchema(chunks=chunks_dict[var])
+    target_schema = DatasetSchema(schema_dict)
+
+    # make storage patterns
+    temp_store, target_store, target_path = make_rechunker_stores(connection_string, output_path)
+
+    # check and see if the output is empty, if there is content, check that it's chunked correctly
+    if len(target_store) > 0:
+        output = xr.open_zarr(target_store)
+        try:
+            # if the content in target path is correctly chunked, return
+            target_schema.validate(output)
+            return output, target_path
+
+        except SchemaError:
+            if overwrite:
+                target_store.clear()
+            else:
+                raise NotImplementedError(
+                    'The content in the output path is incorrectly chunked, but overwrite is disabled.'
+                    'Either clear the output or enable overwrite by setting overwrite=True'
+                )
+
+    # process the input zarr array
+    delete_chunks_encoding(zarr_array)
+    try:
+        # now check if the input is already correctly chunked. If so, save to the output location and return
+        target_schema.validate(zarr_array)
+        zarr_array.to_zarr(target_store, mode='w', consolidated=True)
+        return zarr_array
+
+    except SchemaError:
+        # TODO: could switch this to a validation with xarray schema - confirm that the chunks are all uniform and
+        # if not, chunk them according to the spec provided by `calc_auspicious_chunks_dict`
+        rechunk_plan = rechunk(
+            zarr_array.chunk(chunks_dict),
+            chunks_dict,
+            max_mem,
+            target_store,
+            temp_store=temp_store,
+        )
+        rechunk_plan.execute(retries=5)
+        rechunked_ds = xr.open_zarr(
+            target_store
+        )  # ideally we want consolidated=True but it seems that functionality isn't offered in rechunker right now
+        # we can just add a consolidate_metadata step here to do it after the fact (once rechunker is done) but only
+        # necessary if we'll reopen this rechukned_ds multiple times
+        return rechunked_ds


### PR DESCRIPTION
Changes include:
1. a `get_gcm_grid_spec` function to get the definition of the spatial grid for a gcm 
2. change the `open_era5` function to handle multiple variables
3. new file `paths.py` to store all functions that generate paths for caching/storing 
4. a `rechunk_zarr_array_with_caching` function that handles multiple variables and caches 