### PR TITLE
Functions for loading data and rechunking 

### DIFF
--- a/cmip6_downscaling/config/config.py
+++ b/cmip6_downscaling/config/config.py
@@ -13,7 +13,8 @@ CONNECTION_STRING = connection_string
 storage = Azure("prefect")
 intermediate_cache_path = 'az://flow-outputs/intermediate'
 intermediate_cache_store = CacheStore(intermediate_cache_path)
-results_cache_store = CacheStore('az://flow-outputs/results')
+results_cache_path = 'az://flow-outputs/results'
+results_cache_store = CacheStore(results_cache_path)
 serializer = 'xarray.zarr'
 
 # Prefect --------------------------------------------------------------------

--- a/cmip6_downscaling/config/config.py
+++ b/cmip6_downscaling/config/config.py
@@ -9,8 +9,10 @@ from prefect.storage import Azure
 
 # Azure --------------------------------------------------------------------
 connection_string = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+CONNECTION_STRING = connection_string
 storage = Azure("prefect")
-intermediate_cache_store = CacheStore('az://flow-outputs/intermediate')
+intermediate_cache_path = 'az://flow-outputs/intermediate'
+intermediate_cache_store = CacheStore(intermediate_cache_path)
 results_cache_store = CacheStore('az://flow-outputs/results')
 serializer = 'xarray.zarr'
 

--- a/cmip6_downscaling/data/cmip.py
+++ b/cmip6_downscaling/data/cmip.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Union, Optional
+from typing import List, Optional, Union
 
 import intake
 import numpy as np
@@ -11,7 +11,6 @@ from intake_esm.merge_util import AggregationError
 from cmip6_downscaling.config.config import CONNECTION_STRING
 from cmip6_downscaling.workflows.paths import make_rechunked_gcm_path
 from cmip6_downscaling.workflows.utils import rechunk_zarr_array_with_caching
-
 
 variable_ids = ['pr', 'tasmin', 'tasmax', 'rsds', 'hurs', 'ps']
 
@@ -295,34 +294,34 @@ def get_gcm(
     predict_period_start: str,
     predict_period_end: str,
     chunking_approach: Optional[str] = None,
-    cache_within_rechunk: Optional[bool] = True
+    cache_within_rechunk: Optional[bool] = True,
 ) -> xr.Dataset:
     """
-    Load and combine historical and future GCM into one dataset. 
+    Load and combine historical and future GCM into one dataset.
 
     Parameters
     ----------
     gcm: str
         Name of GCM
     scenario: str
-        Name of scenario 
-    variables: str or list 
-        Name of variable(s) to load 
+        Name of scenario
+    variables: str or list
+        Name of variable(s) to load
     train_period_start: str
-        Start year of train/historical period 
+        Start year of train/historical period
     train_period_end: str
-        End year of train/historical period 
+        End year of train/historical period
     predict_period_start: str
         Start year of predict/future period
     predict_period_end: str
-        End year of predict/future period 
+        End year of predict/future period
     chunking_approach: Optional[str]
-        'full_space', 'full_time', or None 
-    
-    Returns 
+        'full_space', 'full_time', or None
+
+    Returns
     -------
-    ds_gcm: xr.Dataset 
-        A dataset containing both historical and future period of GCM data 
+    ds_gcm: xr.Dataset
+        A dataset containing both historical and future period of GCM data
     """
     historical_gcm = load_cmip(
         activity_ids='CMIP',
@@ -341,7 +340,7 @@ def get_gcm(
     ds_gcm = xr.combine_by_coords([historical_gcm, future_gcm], combine_attrs='drop_conflicts')
 
     if chunking_approach is None:
-        return ds_gcm 
+        return ds_gcm
 
     if cache_within_rechunk:
         path_dict = {
@@ -353,12 +352,9 @@ def get_gcm(
             'predict_period_end': predict_period_end,
             'variables': variables,
         }
-        rechunked_path = make_rechunked_gcm_path(
-            chunking_approach=chunking_approach,
-            **path_dict
-        )
+        rechunked_path = make_rechunked_gcm_path(chunking_approach=chunking_approach, **path_dict)
     else:
-        rechunked_path = None 
+        rechunked_path = None
     ds_gcm_rechunked = rechunk_zarr_array_with_caching(
         zarr_array=ds_gcm,
         connection_string=CONNECTION_STRING,
@@ -370,8 +366,7 @@ def get_gcm(
 
 
 def get_gcm_grid_spec(
-    gcm_name: Optional[str] = None,
-    gcm_ds: Optional[Union[xr.Dataset, xr.DataArray]] = None
+    gcm_name: Optional[str] = None, gcm_ds: Optional[Union[xr.Dataset, xr.DataArray]] = None
 ) -> str:
     if gcm_ds is None:
         assert gcm_name is not None, 'one of gcm_ds or gcm_name has to be not empty'

--- a/cmip6_downscaling/data/cmip.py
+++ b/cmip6_downscaling/data/cmip.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Union
+from typing import List, Union, Optional
 
 import intake
 import numpy as np
@@ -7,6 +7,11 @@ import pandas as pd
 import xarray as xr
 import zarr
 from intake_esm.merge_util import AggregationError
+
+from cmip6_downscaling.config.config import CONNECTION_STRING
+from cmip6_downscaling.workflows.paths import make_rechunked_gcm_path
+from cmip6_downscaling.workflows.utils import rechunk_zarr_array_with_caching
+
 
 variable_ids = ['pr', 'tasmin', 'tasmax', 'rsds', 'hurs', 'ps']
 
@@ -200,32 +205,41 @@ def load_cmip(
     """
     col_url = "https://cmip6downscaling.blob.core.windows.net/cmip6/pangeo-cmip6.json"
 
-    stores = (
-        intake.open_esm_datastore(col_url)
-        .search(
-            activity_id=activity_ids,
-            experiment_id=experiment_ids,
-            member_id=member_ids,
-            source_id=source_ids,
-            table_id=table_ids,
-            grid_label=grid_labels,
-            variable_id=variable_ids,
+    if isinstance(variable_ids, str):
+        variable_ids = [variable_ids]
+
+    for i, var in enumerate(variable_ids):
+        stores = (
+            intake.open_esm_datastore(col_url)
+            .search(
+                activity_id=activity_ids,
+                experiment_id=experiment_ids,
+                member_id=member_ids,
+                source_id=source_ids,
+                table_id=table_ids,
+                grid_label=grid_labels,
+                variable_id=[var],
+            )
+            .df['zstore']
+            .to_list()
         )
-        .df['zstore']
-        .to_list()
-    )
-    if len(stores) > 1:
-        raise ValueError('can only get 1 store at a time')
-    if return_type == 'zarr':
-        ds = zarr.open_consolidated(stores[0], mode='r')
-    elif return_type == 'xr':
-        ds = xr.open_zarr(stores[0], consolidated=True)
 
-    # flip the lats if necessary and drop the extra dims/vars like bnds
+        if len(stores) > 1:
+            raise ValueError('can only get 1 store at a time')
+        if return_type == 'zarr':
+            ds = zarr.open_consolidated(stores[0], mode='r')
+        elif return_type == 'xr':
+            ds = xr.open_zarr(stores[0], consolidated=True)
 
-    ds = gcm_munge(ds)
+        # flip the lats if necessary and drop the extra dims/vars like bnds
+        ds = gcm_munge(ds)
 
-    return ds
+        if i == 0:
+            ds_out = ds
+        else:
+            ds_out[var] = ds[var]
+
+    return ds_out
 
 
 def convert_to_360(lon: Union[float, int]) -> Union[float, int]:
@@ -272,11 +286,101 @@ def gcm_munge(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
-def get_gcm_grid_spec(gcm: str) -> str:
-    gcm_grid = load_cmip(
+def get_gcm(
+    gcm: str,
+    scenario: str,
+    variables: Union[str, List[str]],
+    train_period_start: str,
+    train_period_end: str,
+    predict_period_start: str,
+    predict_period_end: str,
+    chunking_approach: Optional[str] = None,
+    cache_within_rechunk: Optional[bool] = True
+) -> xr.Dataset:
+    """
+    Load and combine historical and future GCM into one dataset. 
+
+    Parameters
+    ----------
+    gcm: str
+        Name of GCM
+    scenario: str
+        Name of scenario 
+    variables: str or list 
+        Name of variable(s) to load 
+    train_period_start: str
+        Start year of train/historical period 
+    train_period_end: str
+        End year of train/historical period 
+    predict_period_start: str
+        Start year of predict/future period
+    predict_period_end: str
+        End year of predict/future period 
+    chunking_approach: Optional[str]
+        'full_space', 'full_time', or None 
+    
+    Returns 
+    -------
+    ds_gcm: xr.Dataset 
+        A dataset containing both historical and future period of GCM data 
+    """
+    historical_gcm = load_cmip(
+        activity_ids='CMIP',
+        experiment_ids='historical',
         source_ids=gcm,
+        variable_ids=variables,
         return_type='xr',
-    ).isel(time=0)
+    ).sel(time=slice(train_period_start, train_period_end))
+    future_gcm = load_cmip(
+        activity_ids='ScenarioMIP',
+        experiment_ids=scenario,
+        source_ids=gcm,
+        variable_ids=variables,
+        return_type='xr',
+    ).sel(time=slice(predict_period_start, predict_period_end))
+    ds_gcm = xr.combine_by_coords([historical_gcm, future_gcm], combine_attrs='drop_conflicts')
+
+    if chunking_approach is None:
+        return ds_gcm 
+
+    if cache_within_rechunk:
+        path_dict = {
+            'gcm': gcm,
+            'scenario': scenario,
+            'train_period_start': train_period_start,
+            'train_period_end': train_period_end,
+            'predict_period_start': predict_period_start,
+            'predict_period_end': predict_period_end,
+            'variables': variables,
+        }
+        rechunked_path = make_rechunked_gcm_path(
+            chunking_approach=chunking_approach,
+            **path_dict
+        )
+    else:
+        rechunked_path = None 
+    ds_gcm_rechunked = rechunk_zarr_array_with_caching(
+        zarr_array=ds_gcm,
+        connection_string=CONNECTION_STRING,
+        chunking_approach=chunking_approach,
+        output_path=rechunked_path,
+    )
+
+    return ds_gcm_rechunked
+
+
+def get_gcm_grid_spec(
+    gcm_name: Optional[str] = None,
+    gcm_ds: Optional[Union[xr.Dataset, xr.DataArray]] = None
+) -> str:
+    if gcm_ds is None:
+        assert gcm_name is not None, 'one of gcm_ds or gcm_name has to be not empty'
+        gcm_grid = load_cmip(
+            source_ids=gcm_name,
+            return_type='xr',
+        ).isel(time=0)
+    else:
+        gcm_grid = gcm_ds.isel(time=0)
 
     nlat = len(gcm_grid.lat)
     nlon = len(gcm_grid.lon)

--- a/cmip6_downscaling/data/observations.py
+++ b/cmip6_downscaling/data/observations.py
@@ -1,7 +1,7 @@
 import os
 
 os.environ["PREFECT__FLOWS__CHECKPOINTING"] = "True"
-from typing import List, Union, Optional
+from typing import List, Optional, Union
 
 import xarray as xr
 import zarr
@@ -9,7 +9,6 @@ import zarr
 from cmip6_downscaling.config.config import CONNECTION_STRING
 from cmip6_downscaling.workflows.paths import make_rechunked_obs_path
 from cmip6_downscaling.workflows.utils import rechunk_zarr_array_with_caching
-
 
 variable_name_dict = {
     "tasmax": "air_temperature_at_2_metres_1hour_Maximum",
@@ -66,17 +65,19 @@ def get_obs(
     train_period_end: str,
     variables: Union[str, List[str]],
     chunking_approach: Optional[str] = None,
-    cache_within_rechunk: Optional[bool] = True
+    cache_within_rechunk: Optional[bool] = True,
 ) -> xr.Dataset:
     if obs == 'ERA5':
-        ds_obs = open_era5(variables=variables, start_year=train_period_start, end_year=train_period_end)
+        ds_obs = open_era5(
+            variables=variables, start_year=train_period_start, end_year=train_period_end
+        )
     else:
         raise NotImplementedError('only ERA5 is available as observation dataset right now')
 
     if chunking_approach is None:
-        return ds_obs 
+        return ds_obs
 
-    if cache_within_rechunk: 
+    if cache_within_rechunk:
         path_dict = {
             'obs': obs,
             'train_period_start': train_period_start,
@@ -88,7 +89,7 @@ def get_obs(
             **path_dict,
         )
     else:
-        rechunked_path = None 
+        rechunked_path = None
     ds_obs_rechunked = rechunk_zarr_array_with_caching(
         zarr_array=ds_obs,
         connection_string=CONNECTION_STRING,

--- a/cmip6_downscaling/workflows/utils.py
+++ b/cmip6_downscaling/workflows/utils.py
@@ -14,7 +14,9 @@ from rechunker import rechunk
 from xarray_schema import DataArraySchema, DatasetSchema
 from xarray_schema.base import SchemaError
 
-schema_maps_chunks = DataArraySchema(chunks={"lat": -1, "lon": -1})
+from cmip6_downscaling.config.config import CONNECTION_STRING, intermediate_cache_path
+
+schema_maps_chunks = DataArraySchema(chunks={'lat': -1, 'lon': -1})
 
 
 def get_store(prefix, account_key=None):
@@ -54,7 +56,7 @@ def delete_chunks_encoding(ds: Union[xr.Dataset, xr.DataArray]):
 
 
 def make_rechunker_stores(
-    connection_string: str,
+    connection_string: Optional[str] = CONNECTION_STRING,
     output_path: Optional[str] = None,
 ) -> Tuple[fsspec.FSMap, fsspec.FSMap, str]:
     """Initialize two stores for rechunker to use as temporary and final rechunked locations
@@ -417,11 +419,13 @@ def write_dataset(ds: xr.Dataset, path: str, chunks_dims: Tuple = ("time",)) -> 
 
 def rechunk_zarr_array_with_caching(
     zarr_array: xr.Dataset,
-    output_path: str,
-    connection_string: str,
-    chunking_approach: str,
+    chunking_approach: Optional[str] = None,
+    template_chunk_array: Optional[xr.Dataset] = None,
+    output_path: Optional[str] = None,
     max_mem: str = "200MB",
     overwrite: bool = False,
+    connection_string: Optional[str] = CONNECTION_STRING,
+    cache_path: Optional[str] = intermediate_cache_path, 
 ) -> xr.Dataset:
     """Use `rechunker` package to adjust chunks of dataset to a form
     conducive for your processing.
@@ -437,8 +441,6 @@ def rechunk_zarr_array_with_caching(
         Has to be one of `full_space` or `full_time`. If `full_space`, the data will be rechunked such that the space dimensions are contiguous (i.e. each chunk
         will contain full maps). If `full_time`, the data will be rechunked such that the time dimension is contiguous (i.e. each chunk will contain full time
         series)
-    connection_string : str
-        Connection string to give you write access
     max_mem : str
         The max memory you want to allow for a chunk. Probably want it to be around 100 MB, but that
         is also controlled by the `calc_auspicious_chunk_sizes` calls.
@@ -451,16 +453,21 @@ def rechunk_zarr_array_with_caching(
         Rechunked dataset
     """
     # determine the chunking schema
-    if chunking_approach == 'full_space':
-        chunk_dims = ('time',)  # if we need full maps, chunk along the time dimension
-    elif chunking_approach == 'full_time':
-        chunk_dims = (
-            'lat',
-            'lon',
-        )  # if we need full time series, chunk along the lat/lon dimensions
+    if template_chunk_array is None:
+        if chunking_approach == 'full_space':
+            chunk_dims = ('time',)  # if we need full maps, chunk along the time dimension
+        elif chunking_approach == 'full_time':
+            chunk_dims = ('lat', 'lon',)  # if we need full time series, chunk along the lat/lon dimensions
+        else:
+            raise NotImplementedError("chunking_approach must be in ['full_space', 'full_time']")
+        example_var = list(zarr_array.data_vars)[0]
+        chunk_def = calc_auspicious_chunks_dict(zarr_array[example_var], chunk_dims=chunk_dims)
     else:
-        raise NotImplementedError("chunking_approach must be in ['full_space', 'full_time']")
-    chunk_def = calc_auspicious_chunks_dict(zarr_array, chunk_dims=chunk_dims)
+        chunk_def = {
+            'time': template_chunk_array.chunks['time'][0],
+            'lat': template_chunk_array.chunks['lat'][0],
+            'lon': template_chunk_array.chunks['lon'][0],
+        }
     chunks_dict = {
         'time': None,  # write None here because you don't want to rechunk this array
         'lon': None,
@@ -468,22 +475,25 @@ def rechunk_zarr_array_with_caching(
     }
     for var in zarr_array.data_vars:
         chunks_dict[var] = chunk_def
+    
 
     # make the schema for what you want the rechunking routine to produce
     # so that you can check whether what you passed in (zarr_array) already looks like that
     # if it does, you'll skip the rechunking!
     schema_dict = {}
     for var in zarr_array.data_vars:
-        schema_dict[var] = DataArraySchema(chunks=chunks_dict[var])
-    print(schema_dict)
+        schema_dict[var] = DataArraySchema(chunks=chunk_def)
     target_schema = DatasetSchema(schema_dict)
 
     # make storage patterns
+    if output_path is not None:
+        output_path = cache_path + '/' + output_path
     temp_store, target_store, target_path = make_rechunker_stores(connection_string, output_path)
+    print(f'target path is {target_path}')
 
     # check and see if the output is empty, if there is content, check that it's chunked correctly
     if len(target_store) > 0:
-        print('in caching')
+        print('checking the cache')
         output = xr.open_zarr(target_store)
         try:
             # if the content in target path is correctly chunked, return
@@ -502,7 +512,7 @@ def rechunk_zarr_array_with_caching(
     # process the input zarr array
     delete_chunks_encoding(zarr_array)
     try:
-        print('verifying current shape')
+        print('checking the chunk')
         # now check if the input is already correctly chunked. If so, save to the output location and return
         target_schema.validate(zarr_array)
         zarr_array.to_zarr(target_store, mode='w', consolidated=True)
@@ -510,20 +520,80 @@ def rechunk_zarr_array_with_caching(
 
     except SchemaError:
         print('rechunking')
-        # TODO: could switch this to a validation with xarray schema - confirm that the chunks are all uniform and
-        # if not, chunk them according to the spec provided by `calc_auspicious_chunks_dict`
-        example_var = list(zarr_array.data_vars)[0]
-        rechunk_plan = rechunk(
-            zarr_array.chunk(chunks_dict[example_var]),
-            chunks_dict,
-            max_mem,
-            target_store,
-            temp_store=temp_store,
-        )
-        rechunk_plan.execute(retries=5)
+        try:
+            rechunk_plan = rechunk(
+                zarr_array,
+                chunks_dict,
+                max_mem,
+                target_store,
+                temp_store=temp_store,
+            )
+            rechunk_plan.execute(retries=5)
+        except ValueError:
+            print(
+                'WARNING: Failed to write zarr store, perhaps because of variable chunk sizes, trying to rechunk it'
+            )
+            # clearing the store because the target store has already been created in the try statement above 
+            # and rechunker fails if there's already content at the target 
+            target_store.clear()
+            zarr_array = zarr_array.chunk(chunks_dict[example_var])
+            rechunk_plan = rechunk(
+                zarr_array,
+                chunks_dict,
+                max_mem,
+                target_store,
+                temp_store=temp_store,
+            )
+            rechunk_plan.execute(retries=5)
         rechunked_ds = xr.open_zarr(
             target_store
         )  # ideally we want consolidated=True but it seems that functionality isn't offered in rechunker right now
         # we can just add a consolidate_metadata step here to do it after the fact (once rechunker is done) but only
         # necessary if we'll reopen this rechukned_ds multiple times
         return rechunked_ds
+
+
+def regrid_ds(
+    ds: xr.Dataset,
+    target_grid_ds: xr.Dataset,
+    rechunked_ds_path: Optional[str] = None,
+    connection_string: Optional[str] = CONNECTION_STRING,
+    **kwargs,
+) -> xr.Dataset:
+    """Regrid a dataset to a target grid. For use in both coarsening or interpolating to finer resolution.
+    The function will check whether the dataset is chunked along time (into spatially-contiguous maps)
+    and if not it will rechunk it. **kwargs are used to construct target path 
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset you want to regrid
+    target_grid_ds : xr.Dataset
+        Template dataset whose grid you'll match
+
+    Returns
+    -------
+    ds_regridded : xr.Dataset
+        Final regridded dataset
+    """
+    # regridding requires ds to be contiguous in lat/lon, check if the input matches the 
+    # target_schema. 
+    schema_dict = {}
+    for var in ds.data_vars:
+        schema_dict[var] = schema_maps_chunks
+    target_schema = DatasetSchema(schema_dict)
+
+    try:
+        target_schema.validate(ds)
+        ds_rechunked = ds
+    except SchemaError:
+        ds_rechunked = rechunk_zarr_array_with_caching(
+            zarr_array=ds,
+            chunking_approach='full_space',
+            max_mem='1GB',
+            connection_string=connection_string
+        )
+    
+    regridder = xe.Regridder(ds_rechunked, target_grid_ds, "bilinear", extrap_method="nearest_s2d")
+    ds_regridded = regridder(ds_rechunked)
+    return ds_regridded

--- a/cmip6_downscaling/workflows/utils.py
+++ b/cmip6_downscaling/workflows/utils.py
@@ -425,7 +425,7 @@ def rechunk_zarr_array_with_caching(
     max_mem: str = "200MB",
     overwrite: bool = False,
     connection_string: Optional[str] = CONNECTION_STRING,
-    cache_path: Optional[str] = intermediate_cache_path, 
+    cache_path: Optional[str] = intermediate_cache_path,
 ) -> xr.Dataset:
     """Use `rechunker` package to adjust chunks of dataset to a form
     conducive for your processing.
@@ -457,7 +457,10 @@ def rechunk_zarr_array_with_caching(
         if chunking_approach == 'full_space':
             chunk_dims = ('time',)  # if we need full maps, chunk along the time dimension
         elif chunking_approach == 'full_time':
-            chunk_dims = ('lat', 'lon',)  # if we need full time series, chunk along the lat/lon dimensions
+            chunk_dims = (
+                'lat',
+                'lon',
+            )  # if we need full time series, chunk along the lat/lon dimensions
         else:
             raise NotImplementedError("chunking_approach must be in ['full_space', 'full_time']")
         example_var = list(zarr_array.data_vars)[0]
@@ -475,7 +478,6 @@ def rechunk_zarr_array_with_caching(
     }
     for var in zarr_array.data_vars:
         chunks_dict[var] = chunk_def
-    
 
     # make the schema for what you want the rechunking routine to produce
     # so that you can check whether what you passed in (zarr_array) already looks like that
@@ -533,8 +535,8 @@ def rechunk_zarr_array_with_caching(
             print(
                 'WARNING: Failed to write zarr store, perhaps because of variable chunk sizes, trying to rechunk it'
             )
-            # clearing the store because the target store has already been created in the try statement above 
-            # and rechunker fails if there's already content at the target 
+            # clearing the store because the target store has already been created in the try statement above
+            # and rechunker fails if there's already content at the target
             target_store.clear()
             zarr_array = zarr_array.chunk(chunks_dict[example_var])
             rechunk_plan = rechunk(
@@ -562,7 +564,7 @@ def regrid_ds(
 ) -> xr.Dataset:
     """Regrid a dataset to a target grid. For use in both coarsening or interpolating to finer resolution.
     The function will check whether the dataset is chunked along time (into spatially-contiguous maps)
-    and if not it will rechunk it. **kwargs are used to construct target path 
+    and if not it will rechunk it. **kwargs are used to construct target path
 
     Parameters
     ----------
@@ -576,8 +578,8 @@ def regrid_ds(
     ds_regridded : xr.Dataset
         Final regridded dataset
     """
-    # regridding requires ds to be contiguous in lat/lon, check if the input matches the 
-    # target_schema. 
+    # regridding requires ds to be contiguous in lat/lon, check if the input matches the
+    # target_schema.
     schema_dict = {}
     for var in ds.data_vars:
         schema_dict[var] = schema_maps_chunks
@@ -591,9 +593,9 @@ def regrid_ds(
             zarr_array=ds,
             chunking_approach='full_space',
             max_mem='1GB',
-            connection_string=connection_string
+            connection_string=connection_string,
         )
-    
+
     regridder = xe.Regridder(ds_rechunked, target_grid_ds, "bilinear", extrap_method="nearest_s2d")
     ds_regridded = regridder(ds_rechunked)
     return ds_regridded


### PR DESCRIPTION
Changes include: 
1. allow load cmip to get multiple variables at once 
2. wrapper function to combine historical/future gcm for downstream processing + rechunking 
3. allow using either a gcm name or an example grid to get gcm grid spec 
4. wrapper function to get obs and rechunk 
5. modify rechunking function to allow using an example ds for chunks and try `.chunk` if rechunker fails 
6. regrid-ds function 