### PR TITLE
Path naming fixes

### DIFF
--- a/cmip6_downscaling/analysis/analysis.py
+++ b/cmip6_downscaling/analysis/analysis.py
@@ -41,7 +41,7 @@ def qaqc_checks(ds: xr.Dataset) -> Tuple[xr.Dataset, xr.Dataset]:
     return annual_qaqc_ts, qaqc_maps
 
 
-def monthly_summary(ds: xr.Dataset) -> xr.Dataset:
+def monthly_summary(ds: xr.Dataset, **kwargs) -> xr.Dataset:
     """Creates an monthly summary dataset.
 
     Parameters
@@ -66,7 +66,7 @@ def monthly_summary(ds: xr.Dataset) -> xr.Dataset:
     return out_ds
 
 
-def annual_summary(ds: xr.Dataset) -> xr.Dataset:
+def annual_summary(ds: xr.Dataset, **kwargs) -> xr.Dataset:
     """Creates an annual summary dataset.
 
     Parameters

--- a/cmip6_downscaling/workflows/bcsd_flow.py
+++ b/cmip6_downscaling/workflows/bcsd_flow.py
@@ -257,9 +257,24 @@ with Flow(
 
     monthly_summary_ds = monthly_summary_task(
         postprocess_bcsd_ds,
+        gcm=gcm,
+        scenario=scenario,
+        variable=variable,
+        train_period=train_period,
+        predict_period=predict_period,
+        bbox=bbox,
+        gcm_identifier=gcm_identifier
     )
 
-    annual_summary_ds = annual_summary_task(postprocess_bcsd_ds)
+    annual_summary_ds = annual_summary_task(
+        postprocess_bcsd_ds,
+        gcm=gcm,
+        scenario=scenario,
+        variable=variable,
+        train_period=train_period,
+        predict_period=predict_period,
+        bbox=bbox,
+        gcm_identifier=gcm_identifier)
 
     pyramid_location_monthly = pyramid.regrid(
         monthly_summary_ds, uri=config.get('storage.results.uri') + pyramid_path_monthly

--- a/cmip6_downscaling/workflows/bcsd_flow.py
+++ b/cmip6_downscaling/workflows/bcsd_flow.py
@@ -175,6 +175,8 @@ with Flow(
         predict_period=predict_period,
         bbox=bbox,
         obs_identifier=obs_identifier,
+        chunking_approach='full_space',
+        gcm_grid_spec=gcm_grid_spec,
     )
 
     spatial_anomalies_ds = get_spatial_anomalies_task(
@@ -187,6 +189,7 @@ with Flow(
         predict_period=predict_period,
         bbox=bbox,
         obs_identifier=obs_identifier,
+        gcm_grid_spec=gcm_grid_spec,
     )
 
     # the next three tasks prepare the inputs required by bcsd
@@ -199,6 +202,8 @@ with Flow(
         predict_period=predict_period,
         bbox=bbox,
         obs_identifier=obs_identifier,
+        chunking_approach='full_time',
+        gcm_grid_spec=gcm_grid_spec,
     )
 
     gcm_train_subset_full_time_ds = return_gcm_train_full_time_task(
@@ -263,7 +268,7 @@ with Flow(
         train_period=train_period,
         predict_period=predict_period,
         bbox=bbox,
-        gcm_identifier=gcm_identifier
+        gcm_identifier=gcm_identifier,
     )
 
     annual_summary_ds = annual_summary_task(
@@ -274,7 +279,8 @@ with Flow(
         train_period=train_period,
         predict_period=predict_period,
         bbox=bbox,
-        gcm_identifier=gcm_identifier)
+        gcm_identifier=gcm_identifier,
+    )
 
     pyramid_location_monthly = pyramid.regrid(
         monthly_summary_ds, uri=config.get('storage.results.uri') + pyramid_path_monthly

--- a/cmip6_downscaling/workflows/paths.py
+++ b/cmip6_downscaling/workflows/paths.py
@@ -107,10 +107,12 @@ def make_rechunked_obs_path(
     if obs_identifier is None:
         obs_identifier = build_obs_identifier(**kwargs)
 
-    return f"rechunked_obs/{obs_identifier}_{chunking_approach}.zarr"
+    return f"rechunked_obs/{obs_identifier}{chunking_approach}.zarr"
 
 
-def make_coarse_obs_path(obs_identifier: str, **kwargs) -> str:
+def make_coarse_obs_path(
+    chunking_approach: str, obs_identifier: str, gcm_grid_spec: str, **kwargs
+) -> str:
     """Build the path for coarsened observation
 
     Parameters
@@ -124,7 +126,7 @@ def make_coarse_obs_path(obs_identifier: str, **kwargs) -> str:
         Path to which coarsened observation defined by the parameters should be stored
     """
 
-    return f"coarsened_obs/{obs_identifier}.zarr"
+    return f"coarsened_obs/{obs_identifier}{chunking_approach}_{gcm_grid_spec}.zarr"
 
 
 def make_interpolated_obs_path(
@@ -148,7 +150,7 @@ def make_interpolated_obs_path(
     """
     if obs_identifier is None:
         obs_identifier = build_obs_identifier(**kwargs)
-    return f"interpolated_obs/{obs_identifier}_{chunking_approach}_{gcm_grid_spec}.zarr"
+    return f"interpolated_obs/{obs_identifier}{chunking_approach}_{gcm_grid_spec}.zarr"
 
 
 def make_interpolated_gcm_path(
@@ -521,7 +523,7 @@ def make_return_obs_path(obs_identifier: str, **kwargs) -> str:
     return f"obs_ds/{obs_identifier}.zarr"
 
 
-def make_spatial_anomalies_path(obs_identifier: str, **kwargs) -> str:
+def make_spatial_anomalies_path(obs_identifier: str, gcm_grid_spec: str, **kwargs) -> str:
     """Build the path for spatial anomalies
 
     Parameters
@@ -534,7 +536,7 @@ def make_spatial_anomalies_path(obs_identifier: str, **kwargs) -> str:
     spatial_anomalies_path : str
         Path to bcsd spatial anomalies file location
     """
-    return f"spatial_anomalies/{obs_identifier}.zarr"
+    return f"spatial_anomalies/{obs_identifier}{gcm_grid_spec}.zarr"
 
 
 def make_gcm_predict_path(gcm_identifier: str = None, **kwargs) -> str:


### PR DESCRIPTION
@tcchiao @norlandrhagen @jhamman 

Two fixes here in response to the most critical aspects of Issue #98 (not the optional naming convention switches):

1) add the `grid_spec` back into the paths - without it we will read the same obs dataset for every GCM which wouldn't match in grid
2) add the `chunking_approach` method back in. This ensures that the coarsened obs used at any given point is chunked in the right way. This fix will make the `full_time` chunked dataset to be used for model training (it isn't being made before this PR).