### PR TITLE
Added overwrite to cache_store to fix empty path error

### DIFF
--- a/cmip6_downscaling/config.py
+++ b/cmip6_downscaling/config.py
@@ -20,6 +20,7 @@ _defaults = {
             'storage_options': {},
         },
         'xpersist_store_name': '/xpersist_metadata_store',
+        'xpersist_overwrite': {'mode': 'w'},
         'web_results': {
             'blob': 'analysis_notebooks',
             'storage_options': {},

--- a/cmip6_downscaling/workflows/bcsd_flow.py
+++ b/cmip6_downscaling/workflows/bcsd_flow.py
@@ -49,12 +49,17 @@ results_cache_store = CacheStore(
     storage_options=config.get("storage.results.storage_options"),
 )
 
+serializer_dump_kwargs = config.get('storage.xpersist_overwrite')
 # Transform Functions into Tasks -----------------------------------------------------------
 
 
 return_obs_task = task(
     return_obs,
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_return_obs_path,
 )
 get_coarse_obs_task = task(
@@ -62,7 +67,11 @@ get_coarse_obs_task = task(
     tags=['dask-resource:TASKSLOTS=1'],
     max_retries=10,
     retry_delay=timedelta(seconds=10),
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_coarse_obs_path,
 )
 get_spatial_anomalies_task = task(
@@ -70,7 +79,11 @@ get_spatial_anomalies_task = task(
     tags=['dask-resource:TASKSLOTS=1'],
     max_retries=10,
     retry_delay=timedelta(seconds=5),
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_spatial_anomalies_path,
 )
 return_coarse_obs_full_time_task = task(
@@ -78,7 +91,11 @@ return_coarse_obs_full_time_task = task(
     tags=['dask-resource:TASKSLOTS=1'],
     max_retries=10,
     retry_delay=timedelta(seconds=5),
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_coarse_obs_path,  # is this right? to have the same target? maybe supposed to be make_rechunked_obs_path
 )
 
@@ -87,7 +104,11 @@ return_gcm_train_full_time_task = task(
     tags=['dask-resource:TASKSLOTS=1'],
     max_retries=10,
     retry_delay=timedelta(seconds=5),
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_rechunked_gcm_path,
 )
 
@@ -96,14 +117,22 @@ return_gcm_predict_rechunked_task = task(
     tags=['dask-resource:TASKSLOTS=1'],
     max_retries=10,
     retry_delay=timedelta(seconds=5),
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_gcm_predict_path,
 )
 
 fit_and_predict_task = task(
     fit_and_predict,
     log_stdout=True,
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_bias_corrected_path,
 )
 
@@ -113,20 +142,26 @@ postprocess_bcsd_task = task(
     max_retries=10,
     retry_delay=timedelta(seconds=5),
     log_stdout=True,
-    result=XpersistResult(results_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        results_cache_store, serializer="xarray.zarr", serializer_dump_kwargs=serializer_dump_kwargs
+    ),
     target=make_bcsd_output_path,
 )
 
 monthly_summary_task = task(
     monthly_summary,
     log_stdout=True,
-    result=XpersistResult(results_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        results_cache_store, serializer="xarray.zarr", serializer_dump_kwargs=serializer_dump_kwargs
+    ),
     target=make_monthly_summary_path,  # TODO: replace with the paradigm from PR #84 once it's merged (also pull that)
 )
 
 annual_summary_task = task(
     annual_summary,
-    result=XpersistResult(results_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        results_cache_store, serializer="xarray.zarr", serializer_dump_kwargs=serializer_dump_kwargs
+    ),
     target=make_annual_summary_path,
 )
 

--- a/cmip6_downscaling/workflows/gard_flow.py
+++ b/cmip6_downscaling/workflows/gard_flow.py
@@ -39,12 +39,17 @@ intermediate_cache_store = CacheStore(
 results_cache_store = CacheStore(
     config.get('storage.results.uri'), storage_options=config.get('storage.results.storage_options')
 )
+serializer_dump_kwargs = config.get('storage.xpersist_overwrite')
 
 
 fit_and_predict_task = task(
     gard_fit_and_predict,
     checkpoint=True,
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_gard_predict_output_path,
 )
 
@@ -56,7 +61,9 @@ read_scrf_task = task(
 
 gard_postprocess_task = task(
     gard_postprocess,
-    result=XpersistResult(results_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        results_cache_store, serializer="xarray.zarr", serializer_dump_kwargs=serializer_dump_kwargs
+    ),
     target=make_gard_post_processed_output_path,
 )
 

--- a/cmip6_downscaling/workflows/maca_flow.py
+++ b/cmip6_downscaling/workflows/maca_flow.py
@@ -36,11 +36,16 @@ intermediate_cache_store = CacheStore(
 results_cache_store = CacheStore(
     config.get('storage.results.uri'), storage_options=config.get('storage.results.storage_options')
 )
+serializer_dump_kwargs = config.get('storage.xpersist_overwrite')
 
 
 @task(
     checkpoint=True,
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_epoch_trend_path,
 )
 def calc_epoch_trend_task(
@@ -132,14 +137,22 @@ def calc_epoch_trend_task(
 
 remove_epoch_trend_task = task(
     remove_epoch_trend,
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_epoch_adjusted_gcm_path,
 )
 
 
 @task(
     checkpoint=True,
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_bias_corrected_gcm_path,
 )
 def maca_coarse_bias_correction_task(
@@ -281,14 +294,22 @@ def subset_task(
 
 maca_construct_analogs_task = task(
     maca_construct_analogs,
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_epoch_adjusted_downscaled_gcm_path,
 )
 
 
 @task(
     checkpoint=True,
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_epoch_adjusted_downscaled_gcm_path,
 )
 def combine_outputs_task(
@@ -325,7 +346,11 @@ def combine_outputs_task(
 
 @task(
     checkpoint=True,
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_epoch_replaced_downscaled_gcm_path,
 )
 def maca_epoch_replacement_task(
@@ -359,7 +384,11 @@ def maca_epoch_replacement_task(
 
 @task(
     checkpoint=True,
-    result=XpersistResult(intermediate_cache_store, serializer="xarray.zarr"),
+    result=XpersistResult(
+        intermediate_cache_store,
+        serializer="xarray.zarr",
+        serializer_dump_kwargs=serializer_dump_kwargs,
+    ),
     target=make_maca_output_path,
 )
 def maca_fine_bias_correction_task(

--- a/notebooks/xpersist_overwrite_example.ipynb
+++ b/notebooks/xpersist_overwrite_example.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7089c0d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from xpersist.prefect.result import XpersistResult\n",
+    "from xpersist import CacheStore\n",
+    "\n",
+    "import xarray as xr\n",
+    "from prefect import task, Flow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83b3b6af",
+   "metadata": {},
+   "source": [
+    "## fails on second run -- after cache_store_key is removed\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d02d709",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "serializer_dump_kwargs = None\n",
+    "dataset_cache_store = CacheStore(\"./\")\n",
+    "\n",
+    "\n",
+    "def load_dataset():\n",
+    "    ds = xr.tutorial.open_dataset(\"air_temperature\")\n",
+    "    print(ds)\n",
+    "    return ds\n",
+    "\n",
+    "\n",
+    "load_dataset_task = task(\n",
+    "    load_dataset,\n",
+    "    result=XpersistResult(\n",
+    "        dataset_cache_store,\n",
+    "        serializer=\"xarray.zarr\",\n",
+    "        serializer_dump_kwargs=serializer_dump_kwargs,\n",
+    "    ),\n",
+    "    target=\"air_temp.zarr\",\n",
+    "    log_stdout=True,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "with Flow(name=\"load_air_temp\") as flow:\n",
+    "    ds = load_dataset_task()\n",
+    "flow.run()\n",
+    "dataset_cache_store.delete(\n",
+    "    key=\"xpersist_metadata_store/air_temp.zarr.artifact.json\", dry_run=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "823e350b",
+   "metadata": {},
+   "source": [
+    "## succeedes on second run -- after cache_store_key is removed\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "169685f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "serializer_dump_kwargs = {\"mode\": \"w\"}\n",
+    "dataset_cache_store = CacheStore(\"./\")\n",
+    "\n",
+    "\n",
+    "def load_dataset():\n",
+    "    ds = xr.tutorial.open_dataset(\"air_temperature\")\n",
+    "    print(ds)\n",
+    "    return ds\n",
+    "\n",
+    "\n",
+    "load_dataset_task = task(\n",
+    "    load_dataset,\n",
+    "    result=XpersistResult(\n",
+    "        dataset_cache_store,\n",
+    "        serializer=\"xarray.zarr\",\n",
+    "        serializer_dump_kwargs=serializer_dump_kwargs,\n",
+    "    ),\n",
+    "    target=\"air_temp.zarr\",\n",
+    "    log_stdout=True,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "with Flow(name=\"load_air_temp\") as flow:\n",
+    "    ds = load_dataset_task()\n",
+    "flow.run()\n",
+    "dataset_cache_store.delete(\n",
+    "    key=\"xpersist_metadata_store/air_temp.zarr.artifact.json\", dry_run=False\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Issue 
This PR addresses the semi-common error I'm running into when running flows. As I understand it, when a flow is interrupted or fails when in the process of writing a zarr store, the store is incomplete and the sidecar xpersist cache store file is not written. On the next run, the xpersist cache recognizes the zarr store, but the sidecar file is missing. This results in the following error: `zarr.errors.ContainsGroupError: path '' contains a group`
<details>
```python
Traceback (most recent call last):
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6/lib/python3.9/site-packages/prefect/engine/runner.py", line 48, in inner
    new_state = method(self, state, *args, **kwargs)
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6/lib/python3.9/site-packages/prefect/engine/task_runner.py", line 926, in get_task_run_state
    result = self.result.write(value, **formatting_kwargs)
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6/lib/python3.9/site-packages/xpersist/prefect/result.py", line 119, in write
    self.cache_store.put(
  File "pydantic/decorator.py", line 39, in pydantic.decorator.validate_arguments.validate.wrapper_function
  File "pydantic/decorator.py", line 133, in pydantic.decorator.ValidatedFunction.call
  File "pydantic/decorator.py", line 200, in pydantic.decorator.ValidatedFunction.execute
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6/lib/python3.9/site-packages/xpersist/cache.py", line 272, in put
    method(artifact)
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6/lib/python3.9/site-packages/xpersist/cache.py", line 277, in _put_skip
    self._put_overwrite(artifact)
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6/lib/python3.9/site-packages/xpersist/cache.py", line 282, in _put_overwrite
    serializer.dump(
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6/lib/python3.9/site-packages/xarray/backends/api.py", line 1391, in to_zarr
    zstore = backends.ZarrStore.open_group(
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6/lib/python3.9/site-packages/xarray/backends/zarr.py", line 386, in open_group
    zarr_group = zarr.open_group(store, **open_kwargs)
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6/lib/python3.9/site-packages/zarr/hierarchy.py", line 1183, in open_group
    raise ContainsGroupError(path)
zarr.errors.ContainsGroupError: path '' contains a group
```

</details>


## Proposed Fix
By specifying the `serializer_dump_kwargs = {"mode": "w"}` (default is `None`) in `XpersistResult`, existing zarr_stores will be overwritten if the associated sidecar cache file is missing. The notebook included in this PR shows the old behavior including the `zarr.errors.ContainsGroupError: path '' contains a group` error as well as the implemented fix. 



## Changes

- config.py was modified to add `serializer_dump_kwargs = {"mode": "w"}`.
- `serializer_dump_kwargs` was added to each cache_store in bcsd_flow.py, maca_flow.py and gard_flow.py.
- The example notebook (`notebooks/xpersist_overwrite_example.ipynb`) was added.