### PR TITLE
Patch/get experiment missing encoding

### DIFF
--- a/cmip6_downscaling/methods/common/tasks.py
+++ b/cmip6_downscaling/methods/common/tasks.py
@@ -94,8 +94,8 @@ def get_obs(run_parameters: RunParameters) -> UPath:
         chunking_schema={'time': 365, 'lat': 150, 'lon': 150},
     )
 
-    if run_parameters.variable != 'pr':
-        del subset[run_parameters.variable].encoding['chunks']
+    for key in subset.variables:
+        subset[key].encoding.pop('chunks', None)
 
     subset.attrs.update({'title': title}, **get_cf_global_attrs(version=version))
     store = subset.to_zarr(target, mode='w', compute=False)
@@ -149,8 +149,9 @@ def get_experiment(run_parameters: RunParameters, time_subset: str) -> UPath:
 
     # Note: dataset is chunked into time:365 chunks to standardize leap-year chunking.
     subset = subset.chunk({'time': 365})
-    if run_parameters.variable != 'pr':
-        del subset[run_parameters.variable].encoding['chunks']
+    for key in subset.variables:
+        subset[key].encoding.pop('chunks', None)
+
     subset.attrs.update({'title': title}, **get_cf_global_attrs(version=version))
     subset.to_zarr(target, mode='w')
     return target


### PR DESCRIPTION
This fixes an error that @norlandrhagen and I have both noticed:

```
022-05-14 01:21:01+0000] INFO - prefect.TaskRunner | Task 'get_experiment': Starting task run...
[2022-05-14 01:21:01+0000] INFO - prefect.TaskRunner | az://scratch/intermediates/0.1.3/get_experiment/f14f69d29cda4831
/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/coding/times.py:351: FutureWarning: Index.ravel returning ndarray is deprecated; in a future version this will return a view on self.
  sample = dates.ravel()[0]
/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/coding/times.py:351: FutureWarning: Index.ravel returning ndarray is deprecated; in a future version this will return a view on self.
  sample = dates.ravel()[0]
/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/coding/times.py:351: FutureWarning: Index.ravel returning ndarray is deprecated; in a future version this will return a view on self.
  sample = dates.ravel()[0]
/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/coding/times.py:351: FutureWarning: Index.ravel returning ndarray is deprecated; in a future version this will return a view on self.
  sample = dates.ravel()[0]
[2022-05-14 01:21:06+0000] ERROR - prefect.TaskRunner | Task 'get_experiment': Exception encountered during task execution!
Traceback (most recent call last):
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/prefect/engine/task_runner.py", line 876, in get_task_run_state
    value = prefect.utilities.executors.run_task_with_timeout(
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/prefect/utilities/executors.py", line 467, in run_task_with_timeout
    return task.run(*args, **kwargs)  # type: ignore
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/cmip6_downscaling/methods/common/tasks.py", line 153, in get_experiment
    del subset[run_parameters.variable].encoding['chunks']
KeyError: 'chunks'
[2022-05-14 01:21:06+0000] INFO - prefect.TaskRunner | Task 'get_experiment': Finished task run for task with final state: 'Failed'
[2022-05-14 01:21:06+0000] INFO - prefect.TaskRunner | Task 'rechunk': Starting task run...
[2022-05-14 01:21:06+0000] INFO - prefect.TaskRunner | Task 'rechunk': Finished task run for task with final state: 'TriggerFailed'
[2022-05-14 01:21:06+0000] ERROR - prefect.TaskRunner | Task 'get_experiment': Exception encountered during task execution!
Traceback (most recent call last):
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/prefect/engine/task_runner.py", line 876, in get_task_run_state
    value = prefect.utilities.executors.run_task_with_timeout(
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/prefect/utilities/executors.py", line 467, in run_task_with_timeout
    return task.run(*args, **kwargs)  # type: ignore
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/cmip6_downscaling/methods/common/tasks.py", line 153, in get_experiment
    del subset[run_parameters.variable].encoding['chunks']
KeyError: 'chunks'
[2022-05-14 01:21:06+0000] INFO - prefect.TaskRunner | Task 'get_experiment': Finished task run for task with final state: 'Failed'
```