### PR TITLE
Fix out of bounds experiment time

### DIFF
--- a/cmip6_downscaling/data/cmip.py
+++ b/cmip6_downscaling/data/cmip.py
@@ -79,6 +79,7 @@ def load_cmip(
     table_ids: str = None,
     grid_labels: str = None,
     variable_ids: list[str] = None,
+    time_slice: slice = None,
 ) -> xr.Dataset:
     """Loads CMIP6 GCM dataset based on input criteria.
 
@@ -98,6 +99,8 @@ def load_cmip(
         grid_labels in CMIP6 catalog, by default ["gn"]
     variable_ids : list, optional
         variable_ids in CMIP6 catalog, by default ['tasmax']
+    time_slice : slice, optional
+        Time slice to subset dataset with
 
     Returns
     -------
@@ -121,7 +124,10 @@ def load_cmip(
         if len(keys) != 1:
             raise ValueError(f'intake-esm search returned {len(keys)}, expected exactly 1.')
 
-        ds = col_subset[keys[0]]().to_dask().pipe(postprocess)
+        ds = col_subset[keys[0]]().to_dask()
+        if time_slice:
+            ds = ds.sel(time=time_slice)
+        ds = ds.pipe(postprocess)
 
         # convert to mm/day - helpful to prevent rounding errors from very tiny numbers
         if 'pr' in ds:
@@ -173,6 +179,7 @@ def get_gcm(
         grid_labels=grid_label,
         source_ids=source_id,
         variable_ids=variable,
+        time_slice=time_slice,
     )
     if float(time_slice.stop) < 2015:
         # you're working with historical data

--- a/cmip6_downscaling/methods/bcsd/flow.py
+++ b/cmip6_downscaling/methods/bcsd/flow.py
@@ -12,6 +12,7 @@ from cmip6_downscaling.methods.bcsd.tasks import (
 )
 from cmip6_downscaling.methods.common.tasks import (  # run_analyses,; get_weights,
     finalize,
+    finalize_on_failure,
     get_experiment,
     get_obs,
     get_pyramid_weights,
@@ -158,4 +159,7 @@ with Flow(
         )
 
     # finalize
-    finalize(p, run_parameters)
+    finalize(run_parameters=run_parameters, **p)
+    finalize_on_failure(run_parameters=run_parameters, **p)
+
+flow.set_reference_tasks([finalize])

--- a/cmip6_downscaling/methods/gard/flow.py
+++ b/cmip6_downscaling/methods/gard/flow.py
@@ -3,8 +3,9 @@ import warnings
 from prefect import Flow, Parameter
 
 from cmip6_downscaling import config, runtimes
-from cmip6_downscaling.methods.common.tasks import (  # annual_summary,; monthly_summary,; pyramid,; run_analyses,; get_weights,
+from cmip6_downscaling.methods.common.tasks import (
     finalize,
+    finalize_on_failure,
     get_experiment,
     get_obs,
     get_pyramid_weights,
@@ -139,4 +140,7 @@ with Flow(
         )
 
     # finalize
-    finalize(p, run_parameters)
+    finalize(run_parameters=run_parameters, **p)
+    finalize_on_failure(run_parameters=run_parameters, **p)
+
+flow.set_reference_tasks([finalize])


### PR DESCRIPTION
This PR fixes a bug where some gcm datasets fail to convert to the standard calendar due to an out of bounds datetime error. For example:

```
022-05-14 18:41:05+0000] ERROR - prefect.TaskRunner | Task 'get_experiment': Exception encountered during task execution!
Traceback (most recent call last):
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/coding/times.py", line 422, in cftime_to_nptime
    dt = pd.Timestamp(
  File "pandas/_libs/tslibs/timestamps.pyx", line 1399, in pandas._libs.tslibs.timestamps.Timestamp.__new__
  File "pandas/_libs/tslibs/conversion.pyx", line 436, in pandas._libs.tslibs.conversion.convert_to_tsobject
  File "pandas/_libs/tslibs/conversion.pyx", line 517, in pandas._libs.tslibs.conversion.convert_datetime_to_tsobject
  File "pandas/_libs/tslibs/np_datetime.pyx", line 120, in pandas._libs.tslibs.np_datetime.check_dts_bounds
pandas._libs.tslibs.np_datetime.OutOfBoundsDatetime: Out of bounds nanosecond timestamp: 2262-04-12 12:00:00

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/prefect/engine/task_runner.py", line 876, in get_task_run_state
    value = prefect.utilities.executors.run_task_with_timeout(
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/prefect/utilities/executors.py", line 467, in run_task_with_timeout
    return task.run(*args, **kwargs)  # type: ignore
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/cmip6_downscaling/methods/common/tasks.py", line 136, in get_experiment
    ds = get_gcm(
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/cmip6_downscaling/data/cmip.py", line 182, in get_gcm
    ds_gcm = load_cmip(activity_ids='ScenarioMIP', experiment_ids=scenario, **kws)
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/cmip6_downscaling/data/cmip.py", line 124, in load_cmip
    ds = col_subset[keys[0]]().to_dask().pipe(postprocess)
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/core/common.py", line 659, in pipe
    return func(self, *args, **kwargs)
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/cmip6_downscaling/data/cmip.py", line 60, in postprocess
    ds = convert_to_standard_calendar(ds)
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/cmip6_downscaling/data/utils.py", line 46, in to_standard_calendar
    obj_new['time'] = obj_new.indexes['time'].to_datetimeindex()
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/coding/cftimeindex.py", line 634, in to_datetimeindex
    nptimes = cftime_to_nptime(self)
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/coding/times.py", line 427, in cftime_to_nptime
    raise ValueError(
ValueError: Cannot convert date 2262-04-12 12:00:00 to a date in the standard calendar.  Reason: Out of bounds nanosecond timestamp: 2262-04-12 12:00:00.
```