### PR TITLE
silence dask slicing and sklearn warnings

### DIFF
--- a/cmip6_downscaling/methods/bcsd/flow.py
+++ b/cmip6_downscaling/methods/bcsd/flow.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import warnings
 
+import dask
 from prefect import Flow, Parameter
+from sklearn.utils.validation import DataConversionWarning
 
 from cmip6_downscaling import config, runtimes
 from cmip6_downscaling.methods.bcsd.tasks import (
@@ -23,10 +25,15 @@ from cmip6_downscaling.methods.common.tasks import (  # run_analyses,; get_weigh
     time_summary,
 )
 
+dask.config.set({"array.slicing.split_large_chunks": True})
 warnings.filterwarnings(
     "ignore",
     "(.*) filesystem path not explicitly implemented. falling back to default implementation. This filesystem may not be tested",
     category=UserWarning,
+)
+warnings.filterwarnings(
+    action='ignore',
+    category=DataConversionWarning,
 )
 
 runtime = runtimes.get_runtime()

--- a/cmip6_downscaling/methods/gard/flow.py
+++ b/cmip6_downscaling/methods/gard/flow.py
@@ -1,6 +1,8 @@
 import warnings
 
+import dask
 from prefect import Flow, Parameter
+from sklearn.utils.validation import DataConversionWarning
 
 from cmip6_downscaling import config, runtimes
 from cmip6_downscaling.methods.common.tasks import (
@@ -17,10 +19,15 @@ from cmip6_downscaling.methods.common.tasks import (
 )
 from cmip6_downscaling.methods.gard.tasks import coarsen_and_interpolate, fit_and_predict, read_scrf
 
+dask.config.set({"array.slicing.split_large_chunks": True})
 warnings.filterwarnings(
     "ignore",
     "(.*) filesystem path not explicitly implemented. falling back to default implementation. This filesystem may not be tested",
     category=UserWarning,
+)
+warnings.filterwarnings(
+    action='ignore',
+    category=DataConversionWarning,
 )
 
 runtime = runtimes.get_runtime()


### PR DESCRIPTION
This PR attempts to silence two of the most verbose warnings printed during our flows right now:

1. The dask large chunk warning. I fix this by setting the split-large-chunks option to True.
2. The sklearn data validation warning. I fix this by globally filtering this warning. A quick example here:

```python
from sklearn.utils.validation import column_or_1d, DataConversionWarning
import warnings


column_or_1d([[1], [2]], warn=True)
```
```
/tmp/ipykernel_1601/1678124796.py:1: DataConversionWarning: A column-vector y was passed when a 1d array was expected. Please change the shape of y to (n_samples, ), for example using ravel().
  column_or_1d([[1], [2]], warn=True)
array([1, 2]
```

but after applying this filter:
```python
warnings.filterwarnings(
    action='ignore',
    category=DataConversionWarning,
)
```
the warning goes away.