### PR TITLE
Fix units when converting precipitation to `mm/day`

### DIFF
--- a/cmip6_downscaling/data/cmip.py
+++ b/cmip6_downscaling/data/cmip.py
@@ -131,9 +131,10 @@ def load_cmip(
 
         # convert to mm/day - helpful to prevent rounding errors from very tiny numbers
         if 'pr' in ds:
-            # with xr.set_options(keep_attrs=True):
-            ds['pr'] *= 86400
-            ds['pr'] = ds['pr'].astype('float32')
+            with xr.set_options(keep_attrs=True):
+                ds['pr'] *= 86400
+                ds['pr'] = ds['pr'].astype('float32')
+                ds['pr'].attrs['units'] = 'mm'
 
         return ds
 


### PR DESCRIPTION
This PR ensures units are present after converting precipitation from density units to `mm/day`. 