### PR TITLE
removed prefect task retry

### DIFF
--- a/cmip6_downscaling/methods/bcsd/flow.py
+++ b/cmip6_downscaling/methods/bcsd/flow.py
@@ -153,9 +153,9 @@ with Flow(
     if config.get('run_options.generate_pyramids'):
         p['pyramid_weights'] = get_pyramid_weights(run_parameters=run_parameters, levels=4)
 
-        p['daily_pyramid_path'] = pyramid(
-            p['final_bcsd_full_space_path'], weights_pyramid_path=p['pyramid_weights'], levels=4
-        )
+        # p['daily_pyramid_path'] = pyramid(
+        #     p['final_bcsd_full_space_path'], weights_pyramid_path=p['pyramid_weights'], levels=4
+        # )
         p['monthly_pyramid_path'] = pyramid(
             p['monthly_summary_full_space_path'],
             weights_pyramid_path=p['pyramid_weights'],

--- a/cmip6_downscaling/methods/bcsd/tasks.py
+++ b/cmip6_downscaling/methods/bcsd/tasks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import warnings
-from datetime import timedelta
 
 import dask
 import xarray as xr
@@ -30,7 +29,7 @@ results_dir = UPath(config.get("storage.results.uri")) / version
 use_cache = config.get('run_options.use_cache')
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def spatial_anomalies(obs_full_time_path: UPath, interpolated_obs_full_time_path: UPath) -> UPath:
     """Returns spatial anomalies
     Calculate the seasonal cycle (12 timesteps) spatial anomaly associated
@@ -131,7 +130,7 @@ def _fit_and_predict_wrapper(xtrain, ytrain, xpred, run_parameters, dim='time'):
     return bias_corrected_ds
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def fit_and_predict(
     experiment_train_full_time_path: UPath,
     experiment_predict_full_time_path: UPath,
@@ -202,7 +201,7 @@ def fit_and_predict(
     return target
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def postprocess_bcsd(
     bias_corrected_fine_full_time_path: UPath, spatial_anomalies_path: UPath
 ) -> UPath:

--- a/cmip6_downscaling/methods/common/tasks.py
+++ b/cmip6_downscaling/methods/common/tasks.py
@@ -6,7 +6,6 @@ import json
 import os
 import warnings
 from dataclasses import asdict
-from datetime import timedelta
 from pathlib import PosixPath
 
 import datatree
@@ -50,13 +49,13 @@ results_dir = UPath(config.get("storage.results.uri")) / version
 use_cache = config.get('run_options.use_cache')
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def make_run_parameters(**kwargs) -> RunParameters:
     """Prefect task wrapper for RunParameters"""
     return RunParameters(**kwargs)
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def get_obs(run_parameters: RunParameters) -> UPath:
     """Task to return observation data subset from input parameters.
 
@@ -101,11 +100,11 @@ def get_obs(run_parameters: RunParameters) -> UPath:
     subset.attrs.update({'title': title}, **get_cf_global_attrs(version=version))
     print(f'writing {target}', subset)
     store = subset.to_zarr(target, mode='w', compute=False)
-    store.compute(retries=5)
+    store.compute(retries=2)
     return target
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def get_experiment(run_parameters: RunParameters, time_subset: str) -> UPath:
     """Prefect task that returns cmip GCM data from input run parameters.
 
@@ -159,7 +158,7 @@ def get_experiment(run_parameters: RunParameters, time_subset: str) -> UPath:
     return target
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def rechunk(
     path: UPath,
     pattern: str = None,
@@ -283,7 +282,7 @@ def rechunk(
     return target
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def time_summary(ds_path: UPath, freq: str) -> UPath:
     """Prefect task to create resampled data. Takes mean of `tasmax` and `tasmin` and sum of `pr`.
 
@@ -317,7 +316,7 @@ def time_summary(ds_path: UPath, freq: str) -> UPath:
     return target
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def get_weights(*, run_parameters, direction, regrid_method="bilinear"):
     """Retrieve pre-generated regridding weights.
 
@@ -351,7 +350,7 @@ def get_weights(*, run_parameters, direction, regrid_method="bilinear"):
     return path
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def get_pyramid_weights(*, run_parameters, levels: int, regrid_method: str = "bilinear"):
     """Retrieve pre-generated regridding pyramids weights.
 
@@ -378,7 +377,7 @@ def get_pyramid_weights(*, run_parameters, levels: int, regrid_method: str = "bi
     return path
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def regrid(source_path: UPath, target_grid_path: UPath, weights_path: UPath = None) -> UPath:
     """Task to regrid a dataset to target grid.
 
@@ -491,7 +490,7 @@ def _pyramid_postprocess(dt: dt.DataTree, levels: int, other_chunks: dict = None
     return dt
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def pyramid(
     ds_path: UPath, weights_pyramid_path: str, levels: int = 2, other_chunks: dict = None
 ) -> UPath:
@@ -545,7 +544,7 @@ def pyramid(
     return target
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def run_analyses(ds_path: UPath, run_parameters: RunParameters) -> UPath:
     """Prefect task to run the analyses on results from a downscaling run.
 
@@ -610,7 +609,7 @@ def run_analyses(ds_path: UPath, run_parameters: RunParameters) -> UPath:
     return executed_notebook_path
 
 
-@task(log_stdout=True, max_retries=3, retry_delay=timedelta(seconds=5))
+@task(log_stdout=True)
 def finalize(run_parameters: RunParameters = None, **paths):
     """Prefect task to finalize the downscaling run.
 

--- a/cmip6_downscaling/methods/gard/flow.py
+++ b/cmip6_downscaling/methods/gard/flow.py
@@ -136,9 +136,9 @@ with Flow(
         # pyramids
         p['pyramid_weights'] = get_pyramid_weights(run_parameters=run_parameters, levels=4)
 
-        p['daily_pyramid_path'] = pyramid(
-            p['full_space_model_output_path'], weights_pyramid_path=p['pyramid_weights'], levels=4
-        )
+        # p['daily_pyramid_path'] = pyramid(
+        #     p['full_space_model_output_path'], weights_pyramid_path=p['pyramid_weights'], levels=4
+        # )
         p['monthly_pyramid_path'] = pyramid(
             p['full_space_model_output_path'], weights_pyramid_path=p['pyramid_weights'], levels=4
         )

--- a/cmip6_downscaling/methods/gard/tasks.py
+++ b/cmip6_downscaling/methods/gard/tasks.py
@@ -184,7 +184,7 @@ def fit_and_predict(
     out = dask.optimize(out)[0]
     # remove apply_land_mask after scikit-downscale#110 is merged
     t = out.pipe(apply_land_mask).to_zarr(target, compute=False, mode='w', consolidated=False)
-    t.compute(retries=5)
+    t.compute(retries=2)
 
     zarr.consolidate_metadata(target)
     return target


### PR DESCRIPTION
All of the retries on put on tasks is really slowing down production runs. 

For example, when a pyramid fails due to an ESMF error, it retries and fails multiple times before moving on to the next parameter set. 

