### PR TITLE
Use land fraction to calculate more inclusive land masks

### DIFF
--- a/cmip6_downscaling/methods/common/utils.py
+++ b/cmip6_downscaling/methods/common/utils.py
@@ -139,7 +139,7 @@ def apply_land_mask(ds: xr.Dataset, how='landfrac') -> xr.Dataset:
     xr.Dataset
     """
 
-    mask = _add_landmask_to_dataset(ds)
+    mask = _add_landmask_to_dataset(ds, how=how)
     return ds.where(mask == 0)
 
 


### PR DESCRIPTION
This is a WIP PR that expands our land mask to include coarse grid cells that have small fractions of land areas. It builds off [xesmf's tutorial](https://pangeo-xesmf.readthedocs.io/en/latest/notebooks/Masking.html) on masking. I think we need to propagate this functionality to the weights generation script (cc @andersy005). 
