### PR TITLE
Fix docs build: pin sphinx to v4.5.0

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - ipykernel
   - ipython
   - setuptools
-  - sphinx
+  - sphinx==4.5.0
   - numpydoc
   - myst-nb
   # this project's dependencies


### PR DESCRIPTION
This is an attempt at fixing documenation builds on vercel.

My current speculation is that the failures have to do with sphinx version. It appears the last successful build used sphinx v4.5.0. 

Cc @jhamman 