### PR TITLE
Remove keep_attrs arg from ds.resample call

### DIFF
--- a/cmip6_downscaling/methods/common/utils.py
+++ b/cmip6_downscaling/methods/common/utils.py
@@ -222,7 +222,7 @@ def _resample_func(ds, freq='1MS'):
     out_ds = xr.Dataset(attrs=ds.attrs)
 
     for v in ds.data_vars:
-        resampler = ds[v].resample(time=freq, keep_attrs=True)
+        resampler = ds[v].resample(time=freq)
         if v in ['tasmax', 'tasmin']:
             out_ds[v] = resampler.mean(dim='time')
         elif v in ['pr']:


### PR DESCRIPTION
This PR removes `keep_attrs` from the `ds.resample` call to address the following warnings during pyramid generation
```
/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/core/common.py:1212: UserWarning: Passing ``keep_attrs`` to ``resample`` has no effect and will raise an error in xarray 0.20. Pass ``keep_attrs`` directly to the applied function, e.g. ``resample(...).mean(keep_attrs=True)``.
  warnings.warn(
```
The argument was removed rather than moved to  ``resample(...).mean(keep_attrs=True)`` since `keep_attrs` is enabled by default since https://github.com/carbonplan/cmip6-downscaling/pull/226, as suggestion by @andersy005.