### PR TITLE
Add carbonplan styles as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 adlfs >= 2022.2.0
 carbonplan_data
+carbonplan[styles]
 cmip6_preprocessing
 dask[complete]
 dask-kubernetes


### PR DESCRIPTION
Adds [carbonplan/styles](https://github.com/carbonplan/styles) as a dependency so that the example notebook works for those who have the cmip6-downscaling package installed.

carbonplan[styles] is used in https://github.com/carbonplan/cmip6-downscaling/blob/main/cmip6_downscaling/analysis/analyses_template.ipynb, https://github.com/carbonplan/cmip6-downscaling/blob/main/notebooks/accessing_data_example.ipynb, and https://github.com/carbonplan/cmip6-downscaling/blob/main/notebooks/figures.ipynb.