### PR TITLE
Separate DeepSD and analysis dependencies from install requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,6 @@ regionmask
 scikit-downscale >= 0.1.2
 scikit-learn
 scipy
-tensorflow
-tensorflow-io
 universal-pathlib >= 0.0.12
 xarray >= 2022.3.0
 xarray-datatree == 0.0.6

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     python_requires=PYTHON_REQUIRES,
     install_requires=INSTALL_REQUIRES,
-    extras_require={"deepsd": ["tensorflow", "tensorflow-io"], "analysis": ["cartopy", "seaborn", carbonplan[styles]]},
+    extras_require={"deepsd": ["tensorflow", "tensorflow-io"], "analysis": ["cartopy", "seaborn", "carbonplan[styles]"]},
     license="MIT",
     keywords="carbon, data, climate",
     use_scm_version={"version_scheme": "post-release", "local_scheme": "dirty-tag"},

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     python_requires=PYTHON_REQUIRES,
     install_requires=INSTALL_REQUIRES,
-    extras_require={"deepsd": ["tensorflow", "tensorflow-io"], "analysis": ["cartopy", "seaborn"]},
+    extras_require={"deepsd": ["tensorflow", "tensorflow-io"], "analysis": ["cartopy", "seaborn", carbonplan[styles]]},
     license="MIT",
     keywords="carbon, data, climate",
     use_scm_version={"version_scheme": "post-release", "local_scheme": "dirty-tag"},

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     include_package_data=True,
     python_requires=PYTHON_REQUIRES,
     install_requires=INSTALL_REQUIRES,
+    extras_require={"deepsd": ["tensorflow", "tensorflow-io"], "analysis": ["cartopy", "seaborn"]},
     license="MIT",
     keywords="carbon, data, climate",
     use_scm_version={"version_scheme": "post-release", "local_scheme": "dirty-tag"},

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,10 @@ setup(
     include_package_data=True,
     python_requires=PYTHON_REQUIRES,
     install_requires=INSTALL_REQUIRES,
-    extras_require={"deepsd": ["tensorflow", "tensorflow-io"], "analysis": ["cartopy", "seaborn", "carbonplan[styles]"]},
+    extras_require={
+        "deepsd": ["tensorflow", "tensorflow-io"],
+        "analysis": ["cartopy", "seaborn", "carbonplan[styles]"],
+    },
     license="MIT",
     keywords="carbon, data, climate",
     use_scm_version={"version_scheme": "post-release", "local_scheme": "dirty-tag"},


### PR DESCRIPTION
Specify these as optional dependencies using `extras_require` (ref. https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies)